### PR TITLE
clarify types for rust/pull/44287

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -159,7 +159,7 @@ fn get_color(mut arg: ::clap::Values) -> Result<[f32; 4], &'static str> {
     ];
 
     if let Some(v) = arg.next() {
-        rgb[3] *= v.parse().map_err(|_| "Second parameter is not a float")?
+        rgb[3] *= v.parse::<f32>().map_err(|_| "Second parameter is not a float")?
     }
 
     Ok(rgb)


### PR DESCRIPTION
If rust/pull/44287 lands  then [cargobomb](https://github.com/rust-lang/rust/pull/44287#issuecomment-329089956) tells us that this line will have a type ambiguity error, so this is a PR to preemptively prevent that.